### PR TITLE
(feat): Add fallback non-assigned block device mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ On the first launch, `ebs-bootstrap` would refuse to perform any modifications t
 ```
 
 [~] sudo ebs-bootstrap -mode=prompt
-🔵 /dev/nvme1n1: Detected Nitro-based AWS NVMe device => /dev/sdb
-🔵 /dev/nvme2n1: Detected Nitro-based AWS NVMe device => /dev/sdh
+🔵 Nitro NVMe detected: /dev/nvme1n1 -> /dev/sdb
+🔵 Nitro NVMe detected: /dev/nvme2n1 -> /dev/sdh
 🟠 Formatting larger disks can take several seconds ⌛
 🟣 Would you like to format /dev/nvme1n1 to ext4? (y/n): y
 ⭐ Successfully formatted /dev/nvme1n1 to ext4

--- a/internal/config/modifier.go
+++ b/internal/config/modifier.go
@@ -42,13 +42,13 @@ func (andm *AwsNitroNVMeModifier) Modify(c *Config) error {
 		if err != nil {
 			return err
 		}
+		log.Printf("🔵 Nitro NVMe detected: %s -> %s", name, bdm)
 		cd, exists := c.Devices[bdm]
 		// We can detect AWS NVMe Devices, but this doesn't neccesarily
 		// mean they will be managed through configuration
 		if !exists {
 			continue
 		}
-		log.Printf("🔵 %s: Detected Nitro-based AWS NVMe device => %s", name, bdm)
 		// Delete the original reference to the device configuration from the
 		// block device mapping retrieved from the NVMe IoCtl interface and
 		// replace it with the actual device name


### PR DESCRIPTION
`ebs-bootstrap` should not fail if an Instance Store volume with an unassigned block device mapping is attached to the EC2 Instance. Especially if this Instance Store volume is not mentioned in the configuration file. Therefore, I have added a fallback clause where in if the Vendor Specific information fails to expose a block device mapping, it will now fallback to a safer option, rather than erroring out.

```
# Before
Vendor Specific: ephemeral0:none -> (Error) ❌

# After
Vendor Specific: ephemeral0:none -> /dev/ephemeral0
```

I've also updated the testing frame work to remove the need to explicitly mention what Vendor Specific Padding to use in the NVMe test cases