### PR TITLE
Ephemeral disks should be able to use 'xvdZ' device naming

### DIFF
--- a/internal/service/nvme.go
+++ b/internal/service/nvme.go
@@ -163,7 +163,7 @@ func (ns *AwsNitroNVMeService) getBlockDeviceMapping(nir *NVMeIoctlResult) (stri
 		// Vendor Specfic (vs)
 		vs := strings.TrimRightFunc(string(nir.IdCtrl.Vs.Bdev[:]), ns.trimBlockDevice)
 		// Regex Block device Mapping
-		rebdm := regexp.MustCompile(`^(ephemeral[0-9]):(sd[a-z]|none)`)
+		rebdm := regexp.MustCompile(`^(ephemeral[0-9]):(sd[a-z]|xvd[a-z]|none)`)
 		// Match Block Device Mapping
 		mbdm := rebdm.FindStringSubmatch(vs)
 		if len(mbdm) != 3 {

--- a/internal/service/nvme_test.go
+++ b/internal/service/nvme_test.go
@@ -79,7 +79,7 @@ func TestGetBlockDeviceMapping(t *testing.T) {
 			ModelNumber:        AMZN_NVME_INS_MN,
 			BlockDevice:        "ephemeral0:vdb",
 			ExpectedOutput:     "",
-			ExpectedError:      fmt.Errorf("🔴 /dev/nvme1n1: Instance-store vendor specific metadata did not match pattern. Pattern=^(ephemeral[0-9]):(sd[a-z]|none), Actual=ephemeral0:vdb"),
+			ExpectedError:      fmt.Errorf("🔴 /dev/nvme1n1: Instance-store vendor specific metadata did not match pattern. Pattern=^(ephemeral[0-9]):(sd[a-z]|xvd[a-z]|none), Actual=ephemeral0:vdb"),
 		},
 		{
 			Name:               "Invalid NVMe Device (Unsupported Vendor ID)",


### PR DESCRIPTION
`/dev/sdX` is considered legacy device names for virtual disks - this adds support for using `/dev/xvdX` as the device name