### PR TITLE
(feat): Resize Physical Volume

### DIFF
--- a/cmd/ebs-bootstrap.go
+++ b/cmd/ebs-bootstrap.go
@@ -62,6 +62,7 @@ func main() {
 	// LVM Layers
 	lvmLayers := []layer.Layer{
 		layer.NewCreatePhysicalVolumeLayer(db, lb),
+		layer.NewResizePhysicalVolumeLayer(lb),
 		layer.NewCreateVolumeGroupLayer(lb),
 		layer.NewCreateLogicalVolumeLayer(lb),
 		layer.NewActivateLogicalVolumeLayer(lb),

--- a/configs/ubuntu.yml
+++ b/configs/ubuntu.yml
@@ -3,15 +3,10 @@ defaults:
 devices:
   /dev/vdb:
     fs: xfs
-    lvm: ifmx-etc
+    lvm: ifmx-var
     mountPoint: /mnt/foo
     user: ubuntu
     group: ubuntu
     permissions: 755
-  /dev/vdc:
-    fs: xfs
-    lvm: ifmx-var
-    mountPoint: /mnt/bar
-    user: ubuntu
-    group: ubuntu
-    permissions: 755
+    resize: true
+    resizeThreshold: 99

--- a/configs/ubuntu.yml
+++ b/configs/ubuntu.yml
@@ -1,12 +1,19 @@
 defaults:
   lvmConsumption: 100
+  resizeFs: true
+  resizeThreshold: 99
 devices:
   /dev/vdb:
     fs: xfs
-    lvm: ifmx-var
+    lvm: ifmx-etc
     mountPoint: /mnt/foo
     user: ubuntu
     group: ubuntu
     permissions: 755
-    resize: true
-    resizeThreshold: 99
+  /dev/vdc:
+    fs: xfs
+    lvm: ifmx-var
+    mountPoint: /mnt/bar
+    user: ubuntu
+    group: ubuntu
+    permissions: 755

--- a/internal/action/lvm.go
+++ b/internal/action/lvm.go
@@ -170,3 +170,42 @@ func (a *ActivateLogicalVolumeAction) Refuse() string {
 func (a *ActivateLogicalVolumeAction) Success() string {
 	return fmt.Sprintf("Successfully activated logical volume %s in volume group %s", a.name, a.volumeGroup)
 }
+
+type ResizePhysicalVolumeAction struct {
+	name       string
+	mode       model.Mode
+	lvmService service.LvmService
+}
+
+func NewResizePhysicalVolumeAction(name string, ls service.LvmService) *ResizePhysicalVolumeAction {
+	return &ResizePhysicalVolumeAction{
+		name:       name,
+		mode:       model.Empty,
+		lvmService: ls,
+	}
+}
+
+func (a *ResizePhysicalVolumeAction) Execute() error {
+	return a.lvmService.ResizePhysicalVolume(a.name)
+}
+
+func (a *ResizePhysicalVolumeAction) GetMode() model.Mode {
+	return a.mode
+}
+
+func (a *ResizePhysicalVolumeAction) SetMode(mode model.Mode) Action {
+	a.mode = mode
+	return a
+}
+
+func (a *ResizePhysicalVolumeAction) Prompt() string {
+	return fmt.Sprintf("Would you like to resize physical volume %s", a.name)
+}
+
+func (a *ResizePhysicalVolumeAction) Refuse() string {
+	return fmt.Sprintf("Refused to resize physical volume %s", a.name)
+}
+
+func (a *ResizePhysicalVolumeAction) Success() string {
+	return fmt.Sprintf("Successfully resized physical volume %s", a.name)
+}

--- a/internal/layer/pv_resize.go
+++ b/internal/layer/pv_resize.go
@@ -66,7 +66,7 @@ func (rpvl *ResizePhysicalVolumeLayer) Validate(c *config.Config) error {
 			continue
 		}
 		if rpvl.lvmBackend.ShouldResizePhysicalVolume(name, ResizeThreshold) {
-			return fmt.Errorf("🔴 %s: Failed to resize physical volume", name)
+			return fmt.Errorf("🔴 %s: Failed to resize validation checks. Physical volume %s still needs to be resized", name, name)
 		}
 	}
 	return nil

--- a/internal/layer/pv_resize.go
+++ b/internal/layer/pv_resize.go
@@ -1,0 +1,90 @@
+package layer
+
+import (
+	"fmt"
+
+	"github.com/reecetech/ebs-bootstrap/internal/action"
+	"github.com/reecetech/ebs-bootstrap/internal/backend"
+	"github.com/reecetech/ebs-bootstrap/internal/config"
+)
+
+const (
+	// The % threshold at which to resize a physical volume
+	// -------------------------------------------------------
+	// If the (physical volume / device size) * 100 falls
+	// under this threshold then we perform a resize operation
+	// -------------------------------------------------------
+	// The smallest gp3 EBS volume you can create is 1GiB (1073741824 bytes).
+	// The default size of the extent of a PV is 4 MiB (4194304 bytes).
+	// Typically, the first extent of a PV is reserved for metadata. This
+	// produces a PV of size 1069547520 bytes (Usage=99.6093%). We ensure
+	// that we set the resize threshold to 99.6% to ensure that a 1 GiB EBS
+	// volume won't be always resized
+	// -------------------------------------------------------
+	// Why not just look for a difference of 4194304 bytes?
+	//	- The size of the extent can be changed by the user
+	//	- Therefore we may not always see a difference of 4194304 bytes between
+	//	  the block device and physical volume size
+	ResizeThreshold = float64(99.6)
+)
+
+type ResizePhysicalVolumeLayer struct {
+	lvmBackend backend.LvmBackend
+}
+
+func NewResizePhysicalVolumeLayer(lb backend.LvmBackend) *ResizePhysicalVolumeLayer {
+	return &ResizePhysicalVolumeLayer{
+		lvmBackend: lb,
+	}
+}
+
+func (rpvl *ResizePhysicalVolumeLayer) Modify(c *config.Config) ([]action.Action, error) {
+	actions := make([]action.Action, 0)
+	for name, cd := range c.Devices {
+		if len(cd.Lvm) == 0 {
+			continue
+		}
+		if !c.GetResizeFs(name) {
+			continue
+		}
+		if !rpvl.lvmBackend.ShouldResizePhysicalVolume(name, ResizeThreshold) {
+			continue
+		}
+		mode := c.GetMode(name)
+		a := rpvl.lvmBackend.ResizePhysicalVolume(name)
+		actions = append(actions, a.SetMode(mode))
+	}
+	return actions, nil
+}
+
+func (rpvl *ResizePhysicalVolumeLayer) Validate(c *config.Config) error {
+	for name, cd := range c.Devices {
+		if len(cd.Lvm) == 0 {
+			continue
+		}
+		if !c.GetResizeFs(name) {
+			continue
+		}
+		if rpvl.lvmBackend.ShouldResizePhysicalVolume(name, ResizeThreshold) {
+			return fmt.Errorf("🔴 %s: Failed to resize physical volume", name)
+		}
+	}
+	return nil
+}
+
+func (rpvl *ResizePhysicalVolumeLayer) Warning() string {
+	return DisabledWarning
+}
+
+func (rpvl *ResizePhysicalVolumeLayer) From(c *config.Config) error {
+	return rpvl.lvmBackend.From(c)
+}
+
+func (rpvl *ResizePhysicalVolumeLayer) ShouldProcess(c *config.Config) bool {
+	for name, cd := range c.Devices {
+		if len(cd.Lvm) > 0 && c.GetResizeFs(name) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/model/lvm.go
+++ b/internal/model/lvm.go
@@ -2,13 +2,20 @@ package model
 
 import "github.com/reecetech/ebs-bootstrap/internal/datastructures"
 
+type Device struct {
+	Name string
+	Size uint64
+}
+
 type PhysicalVolume struct {
 	Name string
+	Size uint64
 }
 
 type VolumeGroup struct {
 	Name           string
 	PhysicalVolume string
+	Size           uint64
 }
 
 type LogicalVolumeState int32
@@ -23,4 +30,5 @@ type LogicalVolume struct {
 	Name        string
 	VolumeGroup string
 	State       LogicalVolumeState
+	Size        uint64
 }

--- a/internal/service/lvm.go
+++ b/internal/service/lvm.go
@@ -102,7 +102,7 @@ func (ls *LinuxLvmService) GetPhysicalVolumes() ([]*model.PhysicalVolume, error)
 	for i, pv := range pr.Report[0].PhysicalVolume {
 		size, err := strconv.ParseUint(pv.PhysicalVolumeSize, 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("🔴 Failed to cast device size to unsigned 64-bit integer")
+			return nil, fmt.Errorf("🔴 Failed to cast physical volume size to unsigned 64-bit integer")
 		}
 		pvs[i] = &model.PhysicalVolume{
 			Name: pv.Name,

--- a/internal/utils/exec.go
+++ b/internal/utils/exec.go
@@ -24,6 +24,7 @@ const (
 	XfsGrowfs Binary = "xfs_growfs"
 	Pvs       Binary = "pvs"
 	PvCreate  Binary = "pvcreate"
+	PvResize  Binary = "pvresize"
 	Vgs       Binary = "vgs"
 	VgCreate  Binary = "vgcreate"
 	Lvs       Binary = "lvs"


### PR DESCRIPTION
Reuse the original `resizeFs` attribute to assess whether the Physical Volume needs to be resized. We determine this by comparing the size of the Physical Volume with the underlying Block Device. I also expanded the `LvmGraph` data structure to store size information of the various LVM objects. This will be useful when we start adding logic to detect whether a logical volume needs to be resized

I want to release another major version of `ebs-bootstrap` where we rename `resizeFs` to `resize`. In my opinion, if you want to resize a filesystem, you probably want to have the underlying Physical Volumes and Logical Volumes extended