### PR TITLE
(bugfix): Lack of volume group should not produce error

### DIFF
--- a/internal/backend/lvm.go
+++ b/internal/backend/lvm.go
@@ -136,7 +136,7 @@ func (lb *LinuxLvmBackend) SearchVolumeGroup(physicalVolume string) (*model.Volu
 	}
 	vgn := lb.lvmGraph.GetChildren(pvn, model.VolumeGroupKind)
 	if len(vgn) == 0 {
-		return nil, fmt.Errorf("🔴 %s: Physical volume has no volume group", physicalVolume)
+		return nil, nil
 	}
 	return &model.VolumeGroup{
 		Name:           vgn[0].Name,


### PR DESCRIPTION
We should not produce an error if a Physical Volume does not have an associated Volume Group. 

I introduced this bug in the release of `1.1.3` [Reference](https://github.com/reecetech/ebs-bootstrap/compare/v1.1.2...v1.1.3#diff-bb4284e131d17db5a0cb0a5e8eae5a2a45c3d8b23d3243ce087d8480447da122R101)
```
$ sudo /usr/local/sbin/ebs-bootstrap -mode prompt
🔵 Nitro NVMe detected: /dev/nvme10n1 -> /dev/sdk
🔵 Nitro NVMe detected: /dev/nvme0n1 -> /dev/sda1
🔵 Nitro NVMe detected: /dev/nvme2n1 -> /dev/sde
🔵 Nitro NVMe detected: /dev/nvme9n1 -> /dev/sdf
🔵 Nitro NVMe detected: /dev/nvme5n1 -> /dev/sdc
🔵 Nitro NVMe detected: /dev/nvme6n1 -> /dev/sdj
🔵 Nitro NVMe detected: /dev/nvme3n1 -> /dev/sdh
🔵 Nitro NVMe detected: /dev/nvme1n1 -> /dev/sdi
🔵 Nitro NVMe detected: /dev/nvme7n1 -> /dev/sdg
🔵 Nitro NVMe detected: /dev/nvme8n1 -> /dev/sdd
🔵 Nitro NVMe detected: /dev/nvme4n1 -> /dev/sdl
🔴 /dev/nvme6n1: Physical volume has no volume group
```