### PR TITLE
(feat): Add test cases for layer.ShouldProcess()

### DIFF
--- a/internal/layer/directory_test.go
+++ b/internal/layer/directory_test.go
@@ -174,3 +174,40 @@ func TestCreateDirectoryLayerValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateDirectoryLayerShouldProcess(t *testing.T) {
+	subtests := []struct {
+		Name           string
+		Config         *config.Config
+		ExpectedOutput bool
+	}{
+		{
+			Name: "At Least Once Device Has Mount Point Specified",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdb": {},
+					"/dev/xvdf": {
+						MountPoint: "/mnt/foo",
+					},
+				},
+			},
+			ExpectedOutput: true,
+		},
+		{
+			Name: "No Device Has Mount Point Specified",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedOutput: false,
+		},
+	}
+	for _, subtest := range subtests {
+		t.Run(subtest.Name, func(t *testing.T) {
+			cdl := NewCreateDirectoryLayer(nil)
+			value := cdl.ShouldProcess(subtest.Config)
+			utils.CheckOutput("cdl.ShouldProcess()", t, subtest.ExpectedOutput, value)
+		})
+	}
+}

--- a/internal/layer/format_test.go
+++ b/internal/layer/format_test.go
@@ -166,3 +166,30 @@ func TestFormatDeviceLayerValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatDeviceLayerShouldProcess(t *testing.T) {
+	subtests := []struct {
+		Name           string
+		Config         *config.Config
+		ExpectedOutput bool
+	}{
+		{
+			Name: "File System Declared",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdf": {
+						Fs: model.Xfs,
+					},
+				},
+			},
+			ExpectedOutput: true,
+		},
+	}
+	for _, subtest := range subtests {
+		t.Run(subtest.Name, func(t *testing.T) {
+			ld := NewFormatDeviceLayer(nil)
+			output := ld.ShouldProcess(subtest.Config)
+			utils.CheckOutput("ld.ShouldProcess()", t, subtest.ExpectedOutput, output)
+		})
+	}
+}

--- a/internal/layer/label_test.go
+++ b/internal/layer/label_test.go
@@ -219,3 +219,45 @@ func TestLabelDeviceLayerValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestLabelDeviceLayerShouldProcess(t *testing.T) {
+	subtests := []struct {
+		Name          string
+		Config        *config.Config
+		ExpectedValue bool
+	}{
+		{
+			Name: "At Least Once Device Has Label Specified",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdb": {
+						Fs:    model.Ext4,
+						Label: "label",
+					},
+					"/dev/xvdf": {
+						Fs: model.Ext4,
+					},
+				},
+			},
+			ExpectedValue: true,
+		},
+		{
+			Name: "No Device Has Label Specified",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdf": {
+						Fs: model.Ext4,
+					},
+				},
+			},
+			ExpectedValue: false,
+		},
+	}
+	for _, subtest := range subtests {
+		t.Run(subtest.Name, func(t *testing.T) {
+			ldl := NewLabelDeviceLayer(nil)
+			value := ldl.ShouldProcess(subtest.Config)
+			utils.CheckOutput("ldl.ShouldProcess()", t, subtest.ExpectedValue, value)
+		})
+	}
+}

--- a/internal/layer/lv_activate_test.go
+++ b/internal/layer/lv_activate_test.go
@@ -1,0 +1,45 @@
+package layer
+
+import (
+	"testing"
+
+	"github.com/reecetech/ebs-bootstrap/internal/config"
+	"github.com/reecetech/ebs-bootstrap/internal/utils"
+)
+
+func TestActivateLogicalVolumeLayerShouldProcess(t *testing.T) {
+	subtests := []struct {
+		Name          string
+		Config        *config.Config
+		ExpectedValue bool
+	}{
+		{
+			Name: "At Least Once Device Has Lvm Specified",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdb": {
+						Lvm: "lvm-id",
+					},
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedValue: true,
+		},
+		{
+			Name: "No Device Has Lvm Specified",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedValue: false,
+		},
+	}
+	for _, subtest := range subtests {
+		t.Run(subtest.Name, func(t *testing.T) {
+			alvl := NewActivateLogicalVolumeLayer(nil)
+			output := alvl.ShouldProcess(subtest.Config)
+			utils.CheckOutput("alvl.ShouldProcess()", t, subtest.ExpectedValue, output)
+		})
+	}
+}

--- a/internal/layer/lv_resize_test.go
+++ b/internal/layer/lv_resize_test.go
@@ -1,0 +1,59 @@
+package layer
+
+import (
+	"testing"
+
+	"github.com/reecetech/ebs-bootstrap/internal/config"
+	"github.com/reecetech/ebs-bootstrap/internal/utils"
+)
+
+func TestResizeLogicalVolumeLayerShouldProcess(t *testing.T) {
+	subtests := []struct {
+		Name          string
+		Config        *config.Config
+		ExpectedValue bool
+	}{
+		{
+			Name: "At Least Once Device Has Lvm Specified and Resize Enabled",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdb": {
+						Lvm: "lvm-id",
+						Options: config.Options{
+							Resize: true,
+						},
+					},
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedValue: true,
+		},
+		{
+			Name: "Device Has Lvm Specified, but Resize Disabled",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdb": {
+						Lvm: "lvm-id",
+					},
+				},
+			},
+			ExpectedValue: false,
+		},
+		{
+			Name: "No Device Has Lvm Specified",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedValue: false,
+		},
+	}
+	for _, subtest := range subtests {
+		t.Run(subtest.Name, func(t *testing.T) {
+			rlvl := NewResizeLogicalVolumeLayer(nil)
+			output := rlvl.ShouldProcess(subtest.Config)
+			utils.CheckOutput("rlvl.ShouldProcess()", t, subtest.ExpectedValue, output)
+		})
+	}
+}

--- a/internal/layer/lv_test.go
+++ b/internal/layer/lv_test.go
@@ -1,0 +1,45 @@
+package layer
+
+import (
+	"testing"
+
+	"github.com/reecetech/ebs-bootstrap/internal/config"
+	"github.com/reecetech/ebs-bootstrap/internal/utils"
+)
+
+func TestCreateLogicalVolumeLayerShouldProcess(t *testing.T) {
+	subtests := []struct {
+		Name          string
+		Config        *config.Config
+		ExpectedValue bool
+	}{
+		{
+			Name: "At Least Once Device Has Lvm Specified",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdb": {
+						Lvm: "lvm-id",
+					},
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedValue: true,
+		},
+		{
+			Name: "No Device Has Lvm Specified",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedValue: false,
+		},
+	}
+	for _, subtest := range subtests {
+		t.Run(subtest.Name, func(t *testing.T) {
+			clvl := NewCreateLogicalVolumeLayer(nil)
+			output := clvl.ShouldProcess(subtest.Config)
+			utils.CheckOutput("clvl.ShouldProcess()", t, subtest.ExpectedValue, output)
+		})
+	}
+}

--- a/internal/layer/mount_test.go
+++ b/internal/layer/mount_test.go
@@ -565,3 +565,40 @@ func TestMountDeviceLayerValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestMountDeviceLayerShouldProcess(t *testing.T) {
+	subtests := []struct {
+		Name           string
+		Config         *config.Config
+		ExpectedOutput bool
+	}{
+		{
+			Name: "At Least Once Device Has Mount Point Specified",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdb": {},
+					"/dev/xvdf": {
+						MountPoint: "/mnt/foo",
+					},
+				},
+			},
+			ExpectedOutput: true,
+		},
+		{
+			Name: "No Device Has Mount Point Specified",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedOutput: false,
+		},
+	}
+	for _, subtest := range subtests {
+		t.Run(subtest.Name, func(t *testing.T) {
+			mdl := NewMountDeviceLayer(nil, nil)
+			output := mdl.ShouldProcess(subtest.Config)
+			utils.CheckOutput("mdl.ShouldProcess()", t, subtest.ExpectedOutput, output)
+		})
+	}
+}

--- a/internal/layer/owner_test.go
+++ b/internal/layer/owner_test.go
@@ -349,3 +349,80 @@ func TestChangeOwnerLayerValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestChangeOwnerLayerShouldProcess(t *testing.T) {
+	subtests := []struct {
+		Name           string
+		Config         *config.Config
+		ExpectedOutput bool
+	}{
+		{
+			Name: "At Least One Device has Mount Point, User and Group Provided",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdb": {
+						MountPoint: "/mnt/foo",
+						User:       "user-a",
+						Group:      "group-a",
+					},
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedOutput: true,
+		},
+		{
+			Name: "Device has Mount Point and User Provided, but not Group",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdb": {
+						MountPoint: "/mnt/foo",
+						User:       "user-a",
+					},
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedOutput: true,
+		},
+		{
+			Name: "Device has Mount Point and Group Provided, but not User",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdb": {
+						MountPoint: "/mnt/foo",
+						Group:      "group-a",
+					},
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedOutput: true,
+		},
+		{
+			Name: "Device has Mount Point Provided, but not User and Group",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdb": {
+						MountPoint: "/mnt/foo",
+					},
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedOutput: false,
+		},
+		{
+			Name: "No Device has Mount Point Provided",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedOutput: false,
+		},
+	}
+	for _, subtest := range subtests {
+		t.Run(subtest.Name, func(t *testing.T) {
+			col := NewChangeOwnerLayer(nil, nil)
+			output := col.ShouldProcess(subtest.Config)
+			utils.CheckOutput("col.ShouldProcess()", t, subtest.ExpectedOutput, output)
+		})
+	}
+}

--- a/internal/layer/permissions_test.go
+++ b/internal/layer/permissions_test.go
@@ -218,3 +218,54 @@ func TestChangePermissionsLayerValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestChangePermissionsLayerShouldProcess(t *testing.T) {
+	subtests := []struct {
+		Name           string
+		Config         *config.Config
+		ExpectedOutput bool
+	}{
+		{
+			Name: "At Least One Device Has a Mount Point and Permissions Declared",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdb": {
+						MountPoint:  "/mnt/foo",
+						Permissions: model.FilePermissions(0755),
+					},
+					"/dev/xvdf": {
+						MountPoint: "/mnt/bar",
+					},
+				},
+			},
+			ExpectedOutput: true,
+		},
+		{
+			Name: "No Device Has a Mount Point and Permissions Declared",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedOutput: false,
+		},
+		{
+			Name: "Device Has a Mount Point Declared, but not Permissions",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdb": {
+						MountPoint: "/mnt/foo",
+					},
+				},
+			},
+			ExpectedOutput: false,
+		},
+	}
+	for _, subtest := range subtests {
+		t.Run(subtest.Name, func(t *testing.T) {
+			cpl := NewChangePermissionsLayer(nil)
+			output := cpl.ShouldProcess(subtest.Config)
+			utils.CheckOutput("cpl.ShouldProcess()", t, subtest.ExpectedOutput, output)
+		})
+	}
+}

--- a/internal/layer/pv_resize_test.go
+++ b/internal/layer/pv_resize_test.go
@@ -1,0 +1,59 @@
+package layer
+
+import (
+	"testing"
+
+	"github.com/reecetech/ebs-bootstrap/internal/config"
+	"github.com/reecetech/ebs-bootstrap/internal/utils"
+)
+
+func TestResizePhysicalVolumeLayerShouldProcess(t *testing.T) {
+	subtests := []struct {
+		Name          string
+		Config        *config.Config
+		ExpectedValue bool
+	}{
+		{
+			Name: "At Least Once Device Has Lvm Specified and Resize Enabled",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdb": {
+						Lvm: "lvm-id",
+						Options: config.Options{
+							Resize: true,
+						},
+					},
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedValue: true,
+		},
+		{
+			Name: "Device Has Lvm Specified, but Resize Disabled",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdb": {
+						Lvm: "lvm-id",
+					},
+				},
+			},
+			ExpectedValue: false,
+		},
+		{
+			Name: "No Device Has Lvm Specified",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedValue: false,
+		},
+	}
+	for _, subtest := range subtests {
+		t.Run(subtest.Name, func(t *testing.T) {
+			rpvl := NewResizePhysicalVolumeLayer(nil)
+			output := rpvl.ShouldProcess(subtest.Config)
+			utils.CheckOutput("rpvl.ShouldProcess()", t, subtest.ExpectedValue, output)
+		})
+	}
+}

--- a/internal/layer/pv_test.go
+++ b/internal/layer/pv_test.go
@@ -1,0 +1,45 @@
+package layer
+
+import (
+	"testing"
+
+	"github.com/reecetech/ebs-bootstrap/internal/config"
+	"github.com/reecetech/ebs-bootstrap/internal/utils"
+)
+
+func TestCreatePhysicalVolumeLayerShouldProcess(t *testing.T) {
+	subtests := []struct {
+		Name          string
+		Config        *config.Config
+		ExpectedValue bool
+	}{
+		{
+			Name: "At Least Once Device Has Lvm Specified",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdb": {
+						Lvm: "lvm-id",
+					},
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedValue: true,
+		},
+		{
+			Name: "No Device Has Lvm Specified",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedValue: false,
+		},
+	}
+	for _, subtest := range subtests {
+		t.Run(subtest.Name, func(t *testing.T) {
+			cpvl := NewCreatePhysicalVolumeLayer(nil, nil)
+			output := cpvl.ShouldProcess(subtest.Config)
+			utils.CheckOutput("cpvl.ShouldProcess()", t, subtest.ExpectedValue, output)
+		})
+	}
+}

--- a/internal/layer/resize_test.go
+++ b/internal/layer/resize_test.go
@@ -288,3 +288,42 @@ func TestResizeDeviceLayerValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestResizeDeviceLayerShouldProcess(t *testing.T) {
+	subtests := []struct {
+		Name           string
+		Config         *config.Config
+		ExpectedOutput bool
+	}{
+		{
+			Name: "At Least Once Device Has Resize Enabled",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdb": {
+						Options: config.Options{
+							Resize: true,
+						},
+					},
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedOutput: true,
+		},
+		{
+			Name: "No Device Has Resize Enabled",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedOutput: false,
+		},
+	}
+	for _, subtest := range subtests {
+		t.Run(subtest.Name, func(t *testing.T) {
+			rl := NewResizeDeviceLayer(nil, nil)
+			output := rl.ShouldProcess(subtest.Config)
+			utils.CheckOutput("rl.ShouldProcess()", t, subtest.ExpectedOutput, output)
+		})
+	}
+}

--- a/internal/layer/vg_test.go
+++ b/internal/layer/vg_test.go
@@ -1,0 +1,45 @@
+package layer
+
+import (
+	"testing"
+
+	"github.com/reecetech/ebs-bootstrap/internal/config"
+	"github.com/reecetech/ebs-bootstrap/internal/utils"
+)
+
+func TestCreateVolumeGroupLayerShouldProcess(t *testing.T) {
+	subtests := []struct {
+		Name          string
+		Config        *config.Config
+		ExpectedValue bool
+	}{
+		{
+			Name: "At Least Once Device Has Lvm Specified",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdb": {
+						Lvm: "lvm-id",
+					},
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedValue: true,
+		},
+		{
+			Name: "No Device Has Lvm Specified",
+			Config: &config.Config{
+				Devices: map[string]config.Device{
+					"/dev/xvdf": {},
+				},
+			},
+			ExpectedValue: false,
+		},
+	}
+	for _, subtest := range subtests {
+		t.Run(subtest.Name, func(t *testing.T) {
+			cvgl := NewCreateVolumeGroupLayer(nil)
+			output := cvgl.ShouldProcess(subtest.Config)
+			utils.CheckOutput("cvgl.ShouldProcess()", t, subtest.ExpectedValue, output)
+		})
+	}
+}


### PR DESCRIPTION
When adding `lvm` support to `ebs-bootstrap`, I realised that **all** layers were being invoked, even if the relevant flag for a layer was disabled across all devices. For example, we were querying for the sizes of all block devices and their file systems, even if the `resize` flag was disabled across all devices.

This was not a huge issue until we added `lvm`. Suddenly the LVM layers were being invoked and attempting to query the system with utilities like `lvs` and `pvs`. We can not reasonably expect that these tools will be pre-installed on the operating system. 

Therefore I expanded the `layer` interface by adding a `ShouldProcess(c *config.Config)` method. This method would assess the `config` and determine whether the `layer` should be invoked. This brings performance gains as now the tool can avoid the invocation of layers that are not relevant to the consumer.

Here are test cases for this new `layer.ShouldProcess()` method