### PR TITLE
(feat): Refactor lsblk -J to lsblk -P + LVM Validation Test Cases

### DIFF
--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -9,6 +9,10 @@ import (
 	"github.com/reecetech/ebs-bootstrap/internal/service"
 )
 
+const (
+	LvmWikiDocumentationUrl = "https://github.com/reecetech/ebs-bootstrap/wiki/LVM"
+)
+
 type Validator interface {
 	Validate(c *Config) error
 }
@@ -47,6 +51,9 @@ func (fsv *FileSystemValidator) Validate(c *Config) error {
 		}
 		if fs == model.Unformatted {
 			return fmt.Errorf("🔴 %s: Must provide a supported file system", name)
+		}
+		if fs == model.Lvm {
+			return fmt.Errorf("🔴 %s: Refer to %s on how to manage LVM file systems", name, LvmWikiDocumentationUrl)
 		}
 	}
 	return nil

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -207,6 +207,17 @@ func TestFileSystemValidator(t *testing.T) {
 			},
 			ExpectedError: fmt.Errorf("🔴 /dev/xvdf: Must provide a supported file system"),
 		},
+		{
+			Name: "LVM File System",
+			Config: &Config{
+				Devices: map[string]Device{
+					"/dev/xvdf": {
+						Fs: model.Lvm,
+					},
+				},
+			},
+			ExpectedError: fmt.Errorf("🔴 /dev/xvdf: Refer to %s on how to manage LVM file systems", LvmWikiDocumentationUrl),
+		},
 	}
 	for _, subtest := range subtests {
 		fsv := NewFileSystemValidator()

--- a/internal/service/filesystem.go
+++ b/internal/service/filesystem.go
@@ -42,7 +42,7 @@ func (fsf *LinuxFileSystemServiceFactory) Select(fs model.FileSystem) (FileSyste
 		return NewXfsService(fsf.RunnerFactory), nil
 	case model.Lvm:
 		//lint:ignore ST1005 This Error Message Is Supposed to Be Prepended With A Device Name
-		return nil, fmt.Errorf("Refer to https://github.com/reecetech/ebs-bootstrap/wiki/LVM on how to manage LVM file systems")
+		return nil, fmt.Errorf("A Physical Volume cannot be queried/modified")
 	case model.Unformatted:
 		//lint:ignore ST1005 This Error Message Is Supposed to Be Prepended With A Device Name
 		return nil, fmt.Errorf("An unformatted file system can not be queried/modified")

--- a/internal/service/filesystem_test.go
+++ b/internal/service/filesystem_test.go
@@ -48,6 +48,13 @@ func TestFileSystemFactory(t *testing.T) {
 			ExpectedOutput: nil,
 			ExpectedError:  fmt.Errorf("An unformatted file system can not be queried/modified"),
 		},
+		{
+			Name:           "LVM",
+			FileSystem:     model.Lvm,
+			CmpOption:      cmp.AllowUnexported(),
+			ExpectedOutput: nil,
+			ExpectedError:  fmt.Errorf("A Physical Volume cannot be queried/modified"),
+		},
 	}
 	for _, subtest := range subtests {
 		t.Run(subtest.Name, func(t *testing.T) {

--- a/internal/service/nvme_test.go
+++ b/internal/service/nvme_test.go
@@ -19,85 +19,85 @@ const (
 
 func TestGetBlockDeviceMapping(t *testing.T) {
 	subtests := []struct {
-		Name               string
-		Device             string
-		VendorId           uint16
-		ModelNumber        string
-		BlockDevice        string
-		ExpectedOutput     string
-		ExpectedError      error
+		Name           string
+		Device         string
+		VendorId       uint16
+		ModelNumber    string
+		BlockDevice    string
+		ExpectedOutput string
+		ExpectedError  error
 	}{
 		{
-			Name:               "EBS NVMe Device + Pre-launch",
-			Device:             "/dev/nvme1n1",
-			VendorId:           AMZN_NVME_VID,
-			ModelNumber:        AMZN_NVME_EBS_MN,
-			BlockDevice:        "sdb",
-			ExpectedOutput:     "/dev/sdb",
-			ExpectedError:      nil,
+			Name:           "EBS NVMe Device + Pre-launch",
+			Device:         "/dev/nvme1n1",
+			VendorId:       AMZN_NVME_VID,
+			ModelNumber:    AMZN_NVME_EBS_MN,
+			BlockDevice:    "sdb",
+			ExpectedOutput: "/dev/sdb",
+			ExpectedError:  nil,
 		},
 		{
-			Name:               "EBS NVMe Device + Post-launch",
-			Device:             "/dev/nvme1n1",
-			VendorId:           AMZN_NVME_VID,
-			ModelNumber:        AMZN_NVME_EBS_MN,
-			BlockDevice:        "/dev/sdb",
-			ExpectedOutput:     "/dev/sdb",
-			ExpectedError:      nil,
+			Name:           "EBS NVMe Device + Post-launch",
+			Device:         "/dev/nvme1n1",
+			VendorId:       AMZN_NVME_VID,
+			ModelNumber:    AMZN_NVME_EBS_MN,
+			BlockDevice:    "/dev/sdb",
+			ExpectedOutput: "/dev/sdb",
+			ExpectedError:  nil,
 		},
 		{
-			Name:               "Instance Store NVMe Device",
-			Device:             "/dev/nvme1n1",
-			VendorId:           AMZN_NVME_VID,
-			ModelNumber:        AMZN_NVME_INS_MN,
-			BlockDevice:        "ephemeral0:sdb",
-			ExpectedOutput:     "/dev/sdb",
-			ExpectedError:      nil,
+			Name:           "Instance Store NVMe Device",
+			Device:         "/dev/nvme1n1",
+			VendorId:       AMZN_NVME_VID,
+			ModelNumber:    AMZN_NVME_INS_MN,
+			BlockDevice:    "ephemeral0:sdb",
+			ExpectedOutput: "/dev/sdb",
+			ExpectedError:  nil,
 		},
 		{
-			Name:               "Instance Store NVMe Device + Null Byte",
-			Device:             "/dev/nvme1n1",
-			VendorId:           AMZN_NVME_VID,
-			ModelNumber:        AMZN_NVME_INS_MN,
-			BlockDevice:        "ephemeral0:sdb\x00a",
-			ExpectedOutput:     "/dev/sdb",
-			ExpectedError:      nil,
+			Name:           "Instance Store NVMe Device + Null Byte",
+			Device:         "/dev/nvme1n1",
+			VendorId:       AMZN_NVME_VID,
+			ModelNumber:    AMZN_NVME_INS_MN,
+			BlockDevice:    "ephemeral0:sdb\x00a",
+			ExpectedOutput: "/dev/sdb",
+			ExpectedError:  nil,
 		},
 		{
-			Name:               "Instance Store NVMe Device + Missing Block Device Mapping",
-			Device:             "/dev/nvme1n1",
-			VendorId:           AMZN_NVME_VID,
-			ModelNumber:        AMZN_NVME_INS_MN,
-			BlockDevice:        "ephemeral0:none",
-			ExpectedOutput:     "/dev/ephemeral0",
-			ExpectedError:      nil,
+			Name:           "Instance Store NVMe Device + Missing Block Device Mapping",
+			Device:         "/dev/nvme1n1",
+			VendorId:       AMZN_NVME_VID,
+			ModelNumber:    AMZN_NVME_INS_MN,
+			BlockDevice:    "ephemeral0:none",
+			ExpectedOutput: "/dev/ephemeral0",
+			ExpectedError:  nil,
 		},
 		{
-			Name:               "Instance Store NVMe Device + Pattern Mismatch",
-			Device:             "/dev/nvme1n1",
-			VendorId:           AMZN_NVME_VID,
-			ModelNumber:        AMZN_NVME_INS_MN,
-			BlockDevice:        "ephemeral0:vdb",
-			ExpectedOutput:     "",
-			ExpectedError:      fmt.Errorf("🔴 /dev/nvme1n1: Instance-store vendor specific metadata did not match pattern. Pattern=^(ephemeral[0-9]):(sd[a-z]|none), Actual=ephemeral0:vdb"),
+			Name:           "Instance Store NVMe Device + Pattern Mismatch",
+			Device:         "/dev/nvme1n1",
+			VendorId:       AMZN_NVME_VID,
+			ModelNumber:    AMZN_NVME_INS_MN,
+			BlockDevice:    "ephemeral0:vdb",
+			ExpectedOutput: "",
+			ExpectedError:  fmt.Errorf("🔴 /dev/nvme1n1: Instance-store vendor specific metadata did not match pattern. Pattern=^(ephemeral[0-9]):(sd[a-z]|none), Actual=ephemeral0:vdb"),
 		},
 		{
-			Name:               "Invalid NVMe Device (Unsupported Vendor ID)",
-			Device:             "/dev/nvme1n1",
-			VendorId:           UNSUPPORTED_NVME_VID,
-			ModelNumber:        AMZN_NVME_EBS_MN,
-			BlockDevice:        "",
-			ExpectedOutput:     "",
-			ExpectedError:      fmt.Errorf("🔴 /dev/nvme1n1 is not an AWS-managed NVME device"),
+			Name:           "Invalid NVMe Device (Unsupported Vendor ID)",
+			Device:         "/dev/nvme1n1",
+			VendorId:       UNSUPPORTED_NVME_VID,
+			ModelNumber:    AMZN_NVME_EBS_MN,
+			BlockDevice:    "",
+			ExpectedOutput: "",
+			ExpectedError:  fmt.Errorf("🔴 /dev/nvme1n1 is not an AWS-managed NVME device"),
 		},
 		{
-			Name:               "Invalid NVMe Device (Unsupported Model Number)",
-			Device:             "/dev/nvme1n1",
-			VendorId:           AMZN_NVME_VID,
-			ModelNumber:        UNSUPPORTED_NVME_MN,
-			BlockDevice:        "",
-			ExpectedOutput:     "",
-			ExpectedError:      fmt.Errorf("🔴 /dev/nvme1n1 is not an AWS-managed NVME device"),
+			Name:           "Invalid NVMe Device (Unsupported Model Number)",
+			Device:         "/dev/nvme1n1",
+			VendorId:       AMZN_NVME_VID,
+			ModelNumber:    UNSUPPORTED_NVME_MN,
+			BlockDevice:    "",
+			ExpectedOutput: "",
+			ExpectedError:  fmt.Errorf("🔴 /dev/nvme1n1 is not an AWS-managed NVME device"),
 		},
 	}
 	for _, subtest := range subtests {


### PR DESCRIPTION
I was experimenting with `ebs-bootstrap` running on RHEL 7.9 and found that `lsblk -J`, a command that returns a JSON representation of a block device, is only supported on relatively modern operating systems. 

After some digging, I found that `lsblk -P` returns a machine readable format response in the form of key-value pairs. Since this machine readable format is supported on older versions of `lsblk`, I refactored any invocations of `lsblk -J` to `lsblk -P`

```
# RHEL 9.2
$ lsblk -o NAME,LABEL,FSTYPE,MOUNTPOINT --nodeps -J /dev/nvme9n1
{
   "blockdevices": [
      {
         "name": "nvme9n1",
         "label": "ifmx-var",
         "fstype": "ext4",
         "mountpoint": null
      }
   ]
}

$ lsblk -o NAME,LABEL,FSTYPE,MOUNTPOINT --nodeps -P /dev/nvme9n1
NAME="nvme9n1" LABEL="ifmx-var" FSTYPE="ext4" MOUNTPOINT=""
```

```
# RHEL 7.9
$ lsblk -o NAME,LABEL,FSTYPE,MOUNTPOINT --nodeps -J /dev/nvme9n1
lsblk: invalid option -- 'J'
...

$ lsblk -o NAME,LABEL,FSTYPE,MOUNTPOINT --nodeps -P /dev/nvme9n1
NAME="nvme9n1" LABEL="ifmx-var" FSTYPE="ext4" MOUNTPOINT=""
```

Additionaly, I use this oppurtunity to improve the test cases around LVM validation and error handling. I introduce a performance optimisation for Regex logic by computing the expressions ahead of time and storing them in top-level variables